### PR TITLE
bug: add JWT token detection and Bearer auth support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR $GOPATH/src/crumbhole
 COPY ci-github-notifier .
 
 # Fetch dependencies
+RUN go mod tidy
 RUN go mod download
 RUN go mod verify
 

--- a/ci-github-notifier/go.mod
+++ b/ci-github-notifier/go.mod
@@ -2,4 +2,7 @@ module github.com/crumbhole/ci-github-notifier
 
 go 1.22
 
-require github.com/imroc/req v0.3.0 // indirect
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/imroc/req v0.3.0
+)


### PR DESCRIPTION
# JWT Token Support and Bearer Authentication - https://github.com/crumbhole/ci-github-notifier/issues/49#issue-2828249295

## Changes
- Added automatic JWT token detection
- Dynamically switches between `token` and `Bearer` authentication schemes based on token type
- Added golang-jwt/jwt v5 dependency for JWT parsing

## Testing
I've performed local testing of the container to verify the new JWT support:

   - Container correctly identified the JWT format
   - Automatically switched to `Bearer` authentication
   - Successfully authenticated with GitHub API
   - Status updates were properly posted
   
   
![image](https://github.com/user-attachments/assets/ef1af8eb-3a77-408e-b955-1760888361ba)

![image](https://github.com/user-attachments/assets/5e62ed04-40ed-4ff9-81f5-c0dfd2a1c516)


## Notes
- The JWT validation is structural only - it verifies the token format but does not validate signatures or claims